### PR TITLE
Game Improvements: Cancel Permissions, Player List, and Duplicate Guess Prevention

### DIFF
--- a/src/commands/game/cancel.js
+++ b/src/commands/game/cancel.js
@@ -1,14 +1,14 @@
 /**
  * @fileoverview Cancel command handler.
  * Handles the `!dice cancel` command to terminate an active game.
- * Only game creator or channel owner can cancel games.
+ * Only channel owner can cancel games.
  * @module commands/game/cancel
  */
 
 /**
  * Handle the cancel dice game command.
  * Cancels the active game in the current channel if the requesting user has permission.
- * Authorization is granted to channel owners and the game creator.
+ * Authorization is granted to channel owners only.
  * @param {import('wolf.js').WOLF} client - WOLF client instance
  * @param {import('wolf.js').CommandContext} command - Command context with request details
  * @param {import('../../managers/GameManager.js').default} game - GameManager instance for game operations
@@ -24,13 +24,11 @@ export default async (client, command, game) => {
     return command.reply(phrase);
   }
 
-  // Check permissions: channel owner or game creator
+  // Check permissions: channel owner only
   const channel = await client.channel.getById(channelId);
   const isChannelOwner = channel.owner.id === userId;
-  const gameCreator = await game.getGameCreator(channelId);
-  const isGameCreator = gameCreator === userId;
 
-  if (!isChannelOwner && !isGameCreator) {
+  if (!isChannelOwner) {
     const phrase = client.phrase.getByCommandAndName(command, "dice_owner_only_command");
     return command.reply(phrase);
   }

--- a/src/game/GameEngine.js
+++ b/src/game/GameEngine.js
@@ -211,6 +211,22 @@ class RedisGameEngine {
       return { success: false, error: validation.error };
     }
 
+    // Check if this guess number has already been taken by another player
+    const round = await this.#store.getRound(channelId);
+    const existingGuesses = Object.entries(round.guesses || {});
+
+    for (const [otherPlayerId, otherGuess] of existingGuesses) {
+      // Skip if it's the same player (they can change their guess)
+      if (parseInt(otherPlayerId, 10) === playerId) {
+        continue;
+      }
+
+      // Check if another player already guessed this number
+      if (otherGuess === guess) {
+        return { success: false, error: "guess_already_taken" };
+      }
+    }
+
     await this.#store.recordGuess(channelId, playerId, guess);
     this.#emit("guess:received", { channelId, playerId, guess });
 
@@ -647,15 +663,6 @@ class RedisGameEngine {
 
   async getRoundInfo(channelId) {
     return this.#store.getRound(channelId);
-  }
-
-  /**
-   * Get game creator ID
-   * @param {number} channelId
-   * @returns {Promise<number|null>}
-   */
-  async getGameCreator(channelId) {
-    return this.#store.getGameCreator(channelId);
   }
 
   /**

--- a/src/game/GameStore.js
+++ b/src/game/GameStore.js
@@ -204,16 +204,6 @@ class RedisGameStore {
   }
 
   /**
-   * Get game creator ID
-   * @param {number} channelId
-   * @returns {Promise<number|null>}
-   */
-  async getGameCreator(channelId) {
-    const creatorId = await this.#redis.hget(this.#gameKey(channelId), "creatorId");
-    return creatorId ? parseInt(creatorId, 10) : null;
-  }
-
-  /**
    * Remove a game and all associated data
    * @param {number} channelId
    * @returns {Promise<{success: boolean, error?: string}>}

--- a/src/phrases/ar.json
+++ b/src/phrases/ar.json
@@ -169,7 +169,7 @@
   },
   {
     "name": "dice_game_round_won",
-    "value": "خسر منافسك {bet}"
+    "value": "خسرت المنافسة على {bet}"
   },
   {
     "name": "dice_game_round_draw",

--- a/src/platform/GameManager.js
+++ b/src/platform/GameManager.js
@@ -342,15 +342,6 @@ class GameManager {
     return this.#engine.getSortedScores(channelId);
   }
 
-  /**
-   * Get game creator ID
-   * @param {number} channelId
-   * @returns {Promise<number|null>}
-   */
-  async getGameCreator(channelId) {
-    return this.#engine.getGameCreator(channelId);
-  }
-
   // ===== Event Handlers =====
 
   /**
@@ -441,10 +432,14 @@ class GameManager {
     const { channelId, round } = data;
     const language = this.#languages.get(channelId) || "en";
 
-    // Store initial player count for final scoring
+    // Store initial player count for final scoring and show player list at game start
     if (round === 1) {
       const players = await this.#engine.getEligiblePlayers(channelId);
       this.#initialPlayerCounts.set(channelId, players.length);
+
+      // Display all players who joined before the game starts
+      const playerList = await this.#messages.formatPlayerList(players);
+      await this.#messages.replyGameStart(channelId, language, playerList);
     }
 
     await this.#messages.replyMakeAGuess(channelId, language);


### PR DESCRIPTION
## Summary

This PR implements three game improvements to enhance the dice bot functionality:

### 1. Restrict Game Cancel to Channel Owners Only
- Removed game creator's ability to cancel games
- Only channel owners can now use `!dice cancel`
- Cleaned up unused `getGameCreator()` methods

### 2. Display Player List at Game Start
- Shows all players who joined when round 1 begins
- Uses existing message infrastructure
- Format: "🎮 The game has started! The players are:\n\n{list}"

### 3. Prevent Duplicate Guess Numbers
- Players can no longer guess numbers already taken by others
- Duplicate guesses are silently rejected
- Players can change their own guess
- Makes the game more strategic and fair

## Files Changed
- `src/commands/game/cancel.js` - Updated cancel permissions
- `src/game/GameEngine.js` - Added duplicate guess validation
- `src/game/GameStore.js` - Removed unused method
- `src/platform/GameManager.js` - Added player list display, removed unused method
- `src/phrases/ar.json` - Minor phrase update

## Testing
All features require manual testing on the WOLF platform:
- Test cancel command with non-owner and owner
- Verify player list displays at game start
- Test duplicate guess rejection

## Related Issues
Closes #[issue-number] (if applicable)